### PR TITLE
Changed the number of the cities, and replaced Null city name with '-'

### DIFF
--- a/cities.sql
+++ b/cities.sql
@@ -22282,7 +22282,7 @@ insert into cities (city_id, name, state_id) values (22265, 'D''alpago', 1813);
 insert into cities (city_id, name, state_id) values (22266, 'Longarone', 1813);
 insert into cities (city_id, name, state_id) values (22267, 'Pedavena', 1813);
 insert into cities (city_id, name, state_id) values (22268, 'San Bartolomeo', 1814);
-insert into cities (city_id, name, state_id) values (22269, '', 1815);
+insert into cities (city_id, name, state_id) values (22269, '-', 1815);
 insert into cities (city_id, name, state_id) values (22270, 'Bagnatica', 1815);
 insert into cities (city_id, name, state_id) values (22271, 'Bergamo', 1815);
 insert into cities (city_id, name, state_id) values (22272, 'Bolgare', 1815);
@@ -22601,7 +22601,6 @@ insert into cities (city_id, name, state_id) values (22584, 'Miglianico', 1826);
 insert into cities (city_id, name, state_id) values (22585, 'Montazzoli', 1826);
 insert into cities (city_id, name, state_id) values (22586, 'Montebello sul Sangro', 1826);
 insert into cities (city_id, name, state_id) values (22587, 'Monteferrante', 1826);
-
 insert into cities (city_id, name, state_id) values (22588, 'Montelapiano', 1826);
 insert into cities (city_id, name, state_id) values (22589, 'Montenerodomo', 1826);
 insert into cities (city_id, name, state_id) values (22590, 'Monteodorisio', 1826);

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 # Oracle Countries States Cities
-Just three tables containing the world's **246 countries**, **4,120 states** and **48,312 cities** in an Oracle-ready script.
+Just three tables containing the world's **246 countries**, **4,120 states** and **48,314 cities** in an Oracle-ready script.
 
 ## Install
 - Execute `install.sql` in your parsing schema.
@@ -21,7 +21,7 @@ state_id | number | No |
 name | varchar2(50 byte) | No |
 country_id | number | No | 1
 
-## Table `cities` (48,312 records)
+## Table `cities` (48,314 records)
 Column Name | Data Type | Nullable | Default
 --- | --- | --- | ---
 city_id | number | No |


### PR DESCRIPTION
- Changed the number of the cities in readme.md to reflect the actual number in cities.sql : **48,314**. 

- Replaced empty city name for city ID **22269** with '-' (zero length string fails Not null constraint set on that column). Tested on Oracle 12.1C